### PR TITLE
Fix Gemfile.lock included in build .gem

### DIFF
--- a/intersight_client.gemspec
+++ b/intersight_client.gemspec
@@ -30,7 +30,11 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'
 
-  s.files         = `find *`.split("\n").uniq.sort.select { |f| !f.empty? }
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").reject do |f|
+      (f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
+    end
+  end
   s.test_files    = `find spec/*`.split("\n")
   s.executables   = []
   s.require_paths = ["lib"]


### PR DESCRIPTION
The existing spec.files includes files which are excluded by .gitignore such as Gemfile.lock.

Switching to use the standard spec.files from `bundle gem` which uses `git ls-files`.