### PR TITLE
Exclude unneeded files from gem

### DIFF
--- a/intersight_client.gemspec
+++ b/intersight_client.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir.chdir(__dir__) do
     `git ls-files -z`.split("\x0").reject do |f|
-      (f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
+      (f == __FILE__) || f.match(%r{\A(?:(?:bin|test|spec|features)/|\.(?:git|travis|circleci|openapi-generator|rubocop\.yml|rspec)|appveyor|intersight-openapi-.*\.yaml)})
     end
   end
   s.test_files    = `find spec/*`.split("\n")


### PR DESCRIPTION
This commit prevents the following files from being included in the built gem:

- `.openapi-generator*`
- `.rspec`
- `.rubocop.yml`
- `intersight-openapi-*.yaml`